### PR TITLE
Don't set `Intl` on `global` in browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var intl = require('intl');
-var isBrowser = require('is-browser');
 var objectAssign = require('object-assign');
 
 module.exports = function (val, opts) {
@@ -16,11 +15,6 @@ module.exports = function (val, opts) {
 
 	var locales = opts.locales;
 	delete opts.locales;
-
-	if (isBrowser) {
-		global.Intl = global.Intl || intl;
-		return new Intl.NumberFormat(locales, opts).format(val);
-	}
 
 	return new intl.NumberFormat(locales, opts).format(val);
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   ],
   "dependencies": {
     "intl": "^1.0.0",
-    "is-browser": "^2.0.1",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Instead it return `intl.NumberFormat` directly. This will fix a bug in Safari where it says `No locale data has been provided for this object yet`.
